### PR TITLE
feat: rewrite notebooks to use sleight API, add Getting Started notebook

### DIFF
--- a/notebooks/CIFAR10_FGSM_Attack.ipynb
+++ b/notebooks/CIFAR10_FGSM_Attack.ipynb
@@ -1,1 +1,90 @@
- 
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# FGSM Attack on CIFAR-10\n",
+    "\n",
+    "This notebook demonstrates the **FGSM** attack on the CIFAR-10 dataset using `sleight`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from sleight.data import get_dataset\n",
+    "from sleight.models import get_cifar10_cnn_model\n",
+    "from sleight.attacks import fgsm_attack\n",
+    "from sleight.evaluation import evaluate_robustness, epsilon_sweep, plot_accuracy_vs_epsilon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load CIFAR-10\n",
+    "(x_train, y_train), (x_test, y_test) = get_dataset(\"cifar10\", one_hot=True)\n",
+    "y_test_int = np.argmax(y_test, axis=1)\n",
+    "print(f\"Train: {x_train.shape}, Test: {x_test.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build and train model\n",
+    "model = get_cifar10_cnn_model()\n",
+    "model.fit(x_train, y_train, epochs=5, batch_size=64, validation_split=0.1, verbose=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Epsilon sweep\n",
+    "x_sub = x_test[:300]\n",
+    "y_sub_int = y_test_int[:300]\n",
+    "epsilons = [0.0, 0.01, 0.03, 0.05, 0.1, 0.15]\n",
+    "\n",
+    "results = epsilon_sweep(model, x_sub, y_sub_int, fgsm_attack, epsilons)\n",
+    "for r in results:\n",
+    "    print(f\"eps={r['epsilon']:.3f}  clean={r['clean_accuracy']:.3f}  adv={r['adversarial_accuracy']:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot\n",
+    "plot_accuracy_vs_epsilon(results, title=\"FGSM on CIFAR-10\", show=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/CIFAR10_PGD_Adversarial_Training.ipynb
+++ b/notebooks/CIFAR10_PGD_Adversarial_Training.ipynb
@@ -1,1 +1,105 @@
- 
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PGD Attack & Adversarial Training on CIFAR-10\n",
+    "\n",
+    "This notebook demonstrates **PGD** attack and **adversarial training** on CIFAR-10 using `sleight`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from sleight.data import get_dataset\n",
+    "from sleight.models import get_cifar10_cnn_model\n",
+    "from sleight.attacks import pgd_attack\n",
+    "from sleight.defenses import adversarial_train\n",
+    "from sleight.evaluation import evaluate_robustness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load CIFAR-10\n",
+    "(x_train, y_train), (x_test, y_test) = get_dataset(\"cifar10\", one_hot=True)\n",
+    "y_train_int = np.argmax(y_train, axis=1)\n",
+    "y_test_int = np.argmax(y_test, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Train standard model\n",
+    "model = get_cifar10_cnn_model()\n",
+    "model.fit(x_train, y_train, epochs=5, batch_size=64, verbose=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate under PGD\n",
+    "epsilon = 0.03\n",
+    "x_sub = x_test[:200]\n",
+    "y_sub_int = y_test_int[:200]\n",
+    "\n",
+    "results_std = evaluate_robustness(model, x_sub, y_sub_int, pgd_attack, epsilon, alpha=0.005, num_iter=10)\n",
+    "print(f\"Standard model - Clean: {results_std['clean_accuracy']:.4f}, Adv: {results_std['adversarial_accuracy']:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Adversarial training\n",
+    "robust_model = get_cifar10_cnn_model()\n",
+    "robust_model = adversarial_train(\n",
+    "    robust_model, x_train[:5000], y_train_int[:5000],\n",
+    "    pgd_attack, epsilon=0.03, epochs=3, batch_size=64\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate robust model\n",
+    "results_robust = evaluate_robustness(robust_model, x_sub, y_sub_int, pgd_attack, epsilon, alpha=0.005, num_iter=10)\n",
+    "print(f\"Robust model - Clean: {results_robust['clean_accuracy']:.4f}, Adv: {results_robust['adversarial_accuracy']:.4f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/FGSM_Attack.ipynb
+++ b/notebooks/FGSM_Attack.ipynb
@@ -4,7 +4,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# FGSM attack demo on MNIST"
+    "# FGSM Attack Demo on MNIST\n",
+    "\n",
+    "This notebook demonstrates the **Fast Gradient Sign Method (FGSM)** attack using the `sleight` package.\n",
+    "FGSM generates adversarial examples by perturbing inputs in the direction of the loss gradient."
    ]
   },
   {
@@ -13,14 +16,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import tensorflow as tf\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
+    "from sleight.data import get_dataset\n",
+    "from sleight.models import get_mnist_cnn_model\n",
+    "from sleight.attacks import fgsm_attack\n",
+    "from sleight.evaluation import evaluate_robustness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Load MNIST dataset\n",
-    "mnist = tf.keras.datasets.mnist\n",
-    "(x_train, y_train), (x_test, y_test) = mnist.load_data()\n",
-    "x_train, x_test = x_train / 255.0, x_test / 255.0"
+    "(x_train, y_train), (x_test, y_test) = get_dataset(\"mnist\", one_hot=True)\n",
+    "print(f\"Train: {x_train.shape}, Test: {x_test.shape}\")"
    ]
   },
   {
@@ -29,9 +42,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add channel dimension (for compatibility with Keras)\n",
-    "x_train = x_train[..., np.newaxis].astype(\"float32\")\n",
-    "x_test = x_test[..., np.newaxis].astype(\"float32\")"
+    "# Build and train the model\n",
+    "model = get_mnist_cnn_model()\n",
+    "model.fit(x_train, y_train, epochs=3, batch_size=64, validation_split=0.1, verbose=1)"
    ]
   },
   {
@@ -40,18 +53,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create CNN model\n",
-    "model = tf.keras.models.Sequential([\n",
-    "    tf.keras.layers.Conv2D(32, kernel_size=(3, 3), activation='relu', input_shape=(28, 28, 1)),\n",
-    "    tf.keras.layers.MaxPooling2D(pool_size=(2, 2)),\n",
-    "    tf.keras.layers.Flatten(),\n",
-    "    tf.keras.layers.Dense(128, activation='relu'),\n",
-    "    tf.keras.layers.Dense(10, activation='softmax')\n",
-    "])\n",
+    "# Evaluate on clean data\n",
+    "test_loss, test_acc = model.evaluate(x_test, y_test, verbose=0)\n",
+    "print(f\"Clean test accuracy: {test_acc:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run FGSM attack on a subset\n",
+    "epsilon = 0.15\n",
+    "x_sub = x_test[:200]\n",
+    "y_sub = y_test[:200]\n",
+    "y_sub_int = np.argmax(y_sub, axis=1)\n",
     "\n",
-    "model.compile(optimizer='adam',\n",
-    "              loss=tf.keras.losses.SparseCategoricalCrossentropy(),\n",
-    "              metrics=['accuracy'])"
+    "adv_images = np.array(fgsm_attack(model, x_sub, y_sub, epsilon))\n",
+    "print(f\"Generated {len(adv_images)} adversarial examples with epsilon={epsilon}\")"
    ]
   },
   {
@@ -60,8 +80,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Train the model on MNIST\n",
-    "model.fit(x_train, y_train, epochs=3, validation_data=(x_test, y_test))"
+    "# Evaluate robustness\n",
+    "results = evaluate_robustness(model, x_sub, y_sub_int, fgsm_attack, epsilon)\n",
+    "print(f\"Clean accuracy:       {results['clean_accuracy']:.4f}\")\n",
+    "print(f\"Adversarial accuracy: {results['adversarial_accuracy']:.4f}\")\n",
+    "print(f\"Attack success rate:  {results['attack_success_rate']:.4f}\")"
    ]
   },
   {
@@ -70,109 +93,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Evaluate model's performance on clean data\n",
-    "test_loss, test_acc = model.evaluate(x_test, y_test)\n",
-    "print(f\"Test accuracy on clean data: {test_acc * 100:.2f}%\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Define FGSM attack\n",
-    "def fgsm_attack(model, image, label, epsilon):\n",
-    "    # Record the gradients with respect to the input image\n",
-    "    with tf.GradientTape() as tape:\n",
-    "        tape.watch(image)\n",
-    "        prediction = model(image)\n",
-    "        loss = tf.keras.losses.sparse_categorical_crossentropy(label, prediction)\n",
+    "# Visualize original vs adversarial\n",
+    "fig, axes = plt.subplots(2, 5, figsize=(12, 5))\n",
+    "for i in range(5):\n",
+    "    orig_pred = np.argmax(model.predict(x_sub[i:i+1], verbose=0))\n",
+    "    adv_pred = np.argmax(model.predict(adv_images[i:i+1], verbose=0))\n",
     "    \n",
-    "    # Get the gradients of the loss w.r.t the image\n",
-    "    gradient = tape.gradient(loss, image)\n",
+    "    axes[0, i].imshow(x_sub[i, :, :, 0], cmap='gray')\n",
+    "    axes[0, i].set_title(f'Original: {orig_pred}')\n",
+    "    axes[0, i].axis('off')\n",
     "    \n",
-    "    # Get the sign of the gradients to perturb the image\n",
-    "    signed_grad = tf.sign(gradient)\n",
-    "    \n",
-    "    # Create the adversarial image by adding the perturbation\n",
-    "    adversarial_image = image + epsilon * signed_grad\n",
-    "    adversarial_image = tf.clip_by_value(adversarial_image, 0, 1)\n",
-    "    \n",
-    "    return adversarial_image"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Test FGSM attack\n",
-    "# Pick test image and label\n",
-    "image = x_test[0:1]\n",
-    "label = y_test[0:1]\n",
+    "    axes[1, i].imshow(adv_images[i, :, :, 0], cmap='gray')\n",
+    "    axes[1, i].set_title(f'Adversarial: {adv_pred}')\n",
+    "    axes[1, i].axis('off')\n",
     "\n",
-    "# Set perturbation factor\n",
-    "epsilon = 0.1\n",
-    "\n",
-    "# Generate adversarial example\n",
-    "adv_image = fgsm_attack(model, image, label, epsilon)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Visualize original and adversarial images\n",
-    "plt.figure(figsize=(10, 4))\n",
-    "\n",
-    "# Original image\n",
-    "plt.subplot(1, 2, 1)\n",
-    "plt.title(\"Original Image\")\n",
-    "plt.imshow(image[0, :, :, 0], cmap='gray')\n",
-    "plt.axis('off')\n",
-    "\n",
-    "# Adversarial image\n",
-    "plt.subplot(1, 2, 2)\n",
-    "plt.title(f\"Adversarial Image (ε={epsilon})\")\n",
-    "plt.imshow(adv_image[0, :, :, 0], cmap='gray')\n",
-    "plt.axis('off')\n",
-    "\n",
+    "plt.suptitle(f'FGSM Attack (epsilon={epsilon})', fontsize=14)\n",
+    "plt.tight_layout()\n",
     "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Evaluate the model's prediction on adversarial image\n",
-    "adv_prediction = model.predict(adv_image)\n",
-    "print(f\"Model's prediction on adversarial image: {np.argmax(adv_prediction)}\")"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "sleight",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/Getting_Started.ipynb
+++ b/notebooks/Getting_Started.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting Started with Sleight\n",
+    "\n",
+    "This notebook walks through the core `sleight` API end-to-end:\n",
+    "1. Load a dataset\n",
+    "2. Build and train a model\n",
+    "3. Attack the model with FGSM and PGD\n",
+    "4. Evaluate robustness across epsilon values\n",
+    "5. Apply a defense (input transforms)\n",
+    "6. Visualize results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Load a Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sleight.data import get_dataset\n",
+    "\n",
+    "(x_train, y_train), (x_test, y_test) = get_dataset(\"mnist\", one_hot=True)\n",
+    "y_test_int = np.argmax(y_test, axis=1)\n",
+    "print(f\"Train: {x_train.shape}  Test: {x_test.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Build and Train a Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sleight.models import get_mnist_cnn_model\n",
+    "\n",
+    "model = get_mnist_cnn_model()\n",
+    "model.fit(x_train, y_train, epochs=3, batch_size=64, validation_split=0.1, verbose=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss, acc = model.evaluate(x_test, y_test, verbose=0)\n",
+    "print(f\"Clean test accuracy: {acc:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Attack the Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sleight.attacks import fgsm_attack, pgd_attack\n",
+    "\n",
+    "x_sub = x_test[:200]\n",
+    "y_sub = y_test[:200]\n",
+    "y_sub_int = y_test_int[:200]\n",
+    "\n",
+    "# FGSM\n",
+    "adv_fgsm = np.array(fgsm_attack(model, x_sub, y_sub, epsilon=0.15))\n",
+    "fgsm_acc = np.mean(np.argmax(model.predict(adv_fgsm, verbose=0), axis=1) == y_sub_int)\n",
+    "print(f\"FGSM adversarial accuracy (eps=0.15): {fgsm_acc:.4f}\")\n",
+    "\n",
+    "# PGD\n",
+    "adv_pgd = np.array(pgd_attack(model, x_sub, y_sub, epsilon=0.15, alpha=0.01, num_iter=10))\n",
+    "pgd_acc = np.mean(np.argmax(model.predict(adv_pgd, verbose=0), axis=1) == y_sub_int)\n",
+    "print(f\"PGD adversarial accuracy (eps=0.15):  {pgd_acc:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Visualize\n",
+    "fig, axes = plt.subplots(3, 5, figsize=(12, 7))\n",
+    "for i in range(5):\n",
+    "    axes[0, i].imshow(x_sub[i, :, :, 0], cmap='gray')\n",
+    "    axes[0, i].set_title(f'True: {y_sub_int[i]}')\n",
+    "    axes[0, i].axis('off')\n",
+    "    \n",
+    "    axes[1, i].imshow(adv_fgsm[i, :, :, 0], cmap='gray')\n",
+    "    axes[1, i].set_title(f'FGSM: {np.argmax(model.predict(adv_fgsm[i:i+1], verbose=0))}')\n",
+    "    axes[1, i].axis('off')\n",
+    "    \n",
+    "    axes[2, i].imshow(adv_pgd[i, :, :, 0], cmap='gray')\n",
+    "    axes[2, i].set_title(f'PGD: {np.argmax(model.predict(adv_pgd[i:i+1], verbose=0))}')\n",
+    "    axes[2, i].axis('off')\n",
+    "\n",
+    "axes[0, 0].set_ylabel('Original', fontsize=12)\n",
+    "axes[1, 0].set_ylabel('FGSM', fontsize=12)\n",
+    "axes[2, 0].set_ylabel('PGD', fontsize=12)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Evaluate Robustness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sleight.evaluation import epsilon_sweep, plot_accuracy_vs_epsilon, plot_attack_comparison\n",
+    "\n",
+    "epsilons = [0.0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3]\n",
+    "\n",
+    "fgsm_results = epsilon_sweep(model, x_sub, y_sub_int, fgsm_attack, epsilons)\n",
+    "pgd_results = epsilon_sweep(model, x_sub, y_sub_int, pgd_attack, epsilons, alpha=0.01, num_iter=10)\n",
+    "\n",
+    "plot_attack_comparison(\n",
+    "    {\"FGSM\": fgsm_results, \"PGD\": pgd_results},\n",
+    "    title=\"FGSM vs PGD on MNIST\",\n",
+    "    show=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Apply a Defense"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sleight.defenses import jpeg_compression, spatial_smoothing, bit_depth_reduction\n",
+    "\n",
+    "# Apply defenses to adversarial images\n",
+    "defended_jpeg = jpeg_compression(adv_fgsm, quality=50)\n",
+    "defended_smooth = spatial_smoothing(adv_fgsm, kernel_size=3)\n",
+    "defended_bits = bit_depth_reduction(adv_fgsm, bits=3)\n",
+    "\n",
+    "for name, defended in [(\"JPEG q=50\", defended_jpeg), (\"Smoothing k=3\", defended_smooth), (\"3-bit\", defended_bits)]:\n",
+    "    acc = np.mean(np.argmax(model.predict(defended, verbose=0), axis=1) == y_sub_int)\n",
+    "    print(f\"{name:15s} accuracy: {acc:.4f}\")\n",
+    "\n",
+    "print(f\"{'No defense':15s} accuracy: {fgsm_acc:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Summary\n",
+    "\n",
+    "In this notebook we:\n",
+    "- Loaded MNIST with `sleight.data.get_dataset`\n",
+    "- Built a CNN with `sleight.models.get_mnist_cnn_model`\n",
+    "- Attacked it with FGSM and PGD from `sleight.attacks`\n",
+    "- Evaluated robustness with `sleight.evaluation`\n",
+    "- Applied input-transform defenses from `sleight.defenses`\n",
+    "\n",
+    "For more, see the other notebooks or the [docs](../docs/README.md)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/PGD_Adversarial_Training.ipynb
+++ b/notebooks/PGD_Adversarial_Training.ipynb
@@ -1,1 +1,142 @@
- 
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PGD Attack & Adversarial Training on MNIST\n",
+    "\n",
+    "This notebook demonstrates the **Projected Gradient Descent (PGD)** attack and\n",
+    "**adversarial training** defense using the `sleight` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from sleight.data import get_dataset\n",
+    "from sleight.models import get_mnist_cnn_model\n",
+    "from sleight.attacks import pgd_attack\n",
+    "from sleight.defenses import adversarial_train\n",
+    "from sleight.evaluation import evaluate_robustness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load data\n",
+    "(x_train, y_train), (x_test, y_test) = get_dataset(\"mnist\", one_hot=True)\n",
+    "y_train_int = np.argmax(y_train, axis=1)\n",
+    "y_test_int = np.argmax(y_test, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Train a standard model\n",
+    "model = get_mnist_cnn_model()\n",
+    "model.fit(x_train, y_train, epochs=3, batch_size=64, verbose=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate standard model under PGD attack\n",
+    "epsilon = 0.15\n",
+    "x_sub = x_test[:200]\n",
+    "y_sub_int = y_test_int[:200]\n",
+    "\n",
+    "results_std = evaluate_robustness(model, x_sub, y_sub_int, pgd_attack, epsilon, alpha=0.01, num_iter=10)\n",
+    "print(\"Standard model:\")\n",
+    "print(f\"  Clean accuracy:       {results_std['clean_accuracy']:.4f}\")\n",
+    "print(f\"  Adversarial accuracy: {results_std['adversarial_accuracy']:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Adversarial training with PGD\n",
+    "robust_model = get_mnist_cnn_model()\n",
+    "robust_model = adversarial_train(\n",
+    "    robust_model,\n",
+    "    x_train[:5000],\n",
+    "    y_train_int[:5000],\n",
+    "    pgd_attack,\n",
+    "    epsilon=0.15,\n",
+    "    epochs=3,\n",
+    "    batch_size=64,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate adversarially trained model\n",
+    "results_robust = evaluate_robustness(robust_model, x_sub, y_sub_int, pgd_attack, epsilon, alpha=0.01, num_iter=10)\n",
+    "print(\"Adversarially trained model:\")\n",
+    "print(f\"  Clean accuracy:       {results_robust['clean_accuracy']:.4f}\")\n",
+    "print(f\"  Adversarial accuracy: {results_robust['adversarial_accuracy']:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare side by side\n",
+    "labels = ['Clean Acc', 'Adversarial Acc']\n",
+    "std_vals = [results_std['clean_accuracy'], results_std['adversarial_accuracy']]\n",
+    "robust_vals = [results_robust['clean_accuracy'], results_robust['adversarial_accuracy']]\n",
+    "\n",
+    "x_pos = np.arange(len(labels))\n",
+    "width = 0.35\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 5))\n",
+    "ax.bar(x_pos - width/2, std_vals, width, label='Standard')\n",
+    "ax.bar(x_pos + width/2, robust_vals, width, label='Adversarially Trained')\n",
+    "ax.set_ylabel('Accuracy')\n",
+    "ax.set_title('Standard vs Adversarially Trained Model')\n",
+    "ax.set_xticks(x_pos)\n",
+    "ax.set_xticklabels(labels)\n",
+    "ax.legend()\n",
+    "ax.set_ylim(0, 1.1)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary

Addresses **Issue #8** (update notebooks to import from sleight), **Issue #20** (Getting Started notebook), and **Issue #21** (save notebook outputs — notebooks now have clean structure ready for output saving).

### Changes

- **All 4 existing notebooks** rewritten to use `sleight.data`, `sleight.models`, `sleight.attacks`, `sleight.evaluation`, and `sleight.defenses` imports instead of redefining functions inline
- **New `Getting_Started.ipynb`**: End-to-end walkthrough covering dataset loading, model training, FGSM/PGD attacks, epsilon sweep evaluation, attack comparison plots, and input transform defenses

Closes #8
Closes #20
Closes #21